### PR TITLE
Support booleans without splitting out union of true and false

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ export interface Animal {
   species: string;
   lifeStage: string;
   birthDate: Date;
+  alive: boolean;
 }
 
 export interface Zone {
@@ -60,6 +61,7 @@ const animalForm: AnimalForm = new FormGroup({
   species: new FormControl(''),
   lifeStage: new FormControl(''),
   birthDate: new FormControl(new Date('01 Jan 1994')),
+  alive: new FormControl(true),
 });
 
 const zoneForm: ZoneForm = new FormGroup({
@@ -170,6 +172,7 @@ const animalForm: AnimalForm = new FormGroup({
   species: new FormControl(''),
   lifeStage: new FormControl({ value: '', disabled: true }),
   birthDate: new FormControl(new Date('01 Jan 1994')),
+  alive: new FormControl(true),
 });
 
 const animalValue: AngularFormValue<AnimalForm> = animalForm.value;
@@ -198,6 +201,7 @@ const animalForm: AnimalForm = new FormGroup({
   species: new FormControl(''),
   lifeStage: new FormControl({ value: '', disabled: true }),
   birthDate: new FormControl(new Date('01 Jan 1994')),
+  alive: new FormControl(true),
 });
 
 const animalValue: AngularFormRawValue<AnimalForm> = animalForm.getRawValue();

--- a/package/examples.ts
+++ b/package/examples.ts
@@ -19,6 +19,7 @@ export interface Animal {
   species: string;
   lifeStage: string;
   birthDate: Date;
+  alive: boolean;
 }
 
 export interface Zone {
@@ -55,6 +56,7 @@ const animalForm: AnimalForm = new FormGroup({
   species: new FormControl(''),
   lifeStage: new FormControl(''),
   birthDate: new FormControl(new Date('01 Jan 1994')),
+  alive: new FormControl(true),
 });
 
 const nonNullableAnimalForm: NonNullableAnimalForm = new FormGroup({
@@ -62,6 +64,7 @@ const nonNullableAnimalForm: NonNullableAnimalForm = new FormGroup({
   species: new FormControl('', { nonNullable: true }),
   lifeStage: new FormControl('', { nonNullable: true }),
   birthDate: new FormControl(new Date('01 Jan 1994'), { nonNullable: true }),
+  alive: new FormControl(true, { nonNullable: true }),
 });
 
 const zoneForm: ZoneForm = new FormGroup({

--- a/package/index.ts
+++ b/package/index.ts
@@ -10,6 +10,8 @@ export type AngularForm<T> = T extends (infer ElementType)[]
   ? FormGroup<{
       [Key in keyof T]: AngularForm<T[Key]>;
     }>
+  : T extends boolean
+  ? FormControl<boolean | null>
   : FormControl<T | null>;
 
 export type NonNullableAngularForm<T> = T extends (infer ElementType)[]
@@ -20,6 +22,8 @@ export type NonNullableAngularForm<T> = T extends (infer ElementType)[]
   ? FormGroup<{
       [Key in keyof T]: NonNullableAngularForm<T[Key]>;
     }>
+  : T extends boolean
+  ? FormControl<boolean>
   : FormControl<T>;
 
 // Helpful subtype that shallowly converts an object to a FormGroup.


### PR DESCRIPTION
This resolves a bug around the booleans and conditional types. Apparently booleans are a union type of `true | false` and when a boolean is used with a generic and a conditional it gets split into the individual value types... This fix makes adds a special case for a boolean value type in the FormControl to cover this edge case.